### PR TITLE
Fix segment edit link

### DIFF
--- a/src/wagtail_personalisation/templates/modeladmin/wagtail_personalisation/segment/dashboard.html
+++ b/src/wagtail_personalisation/templates/modeladmin/wagtail_personalisation/segment/dashboard.html
@@ -22,7 +22,7 @@
                         <div class="nice-padding block_container">
                             {% if all_count %}
                                 {% for segment in object_list %}
-                                    <div class="block block--{{ segment.status }}" onclick="location.href = 'edit/{{ segment.pk }}'">
+                                    <div class="block block--{{ segment.status }}" onclick="location.href = '{% url 'wagtail_personalisation_segment_modeladmin_edit' segment.pk %}'">
                                         <h2>{{ segment }}</h2>
                                         <div class="inspect_container">
                                             <ul class="inspect segment_stats">
@@ -90,7 +90,7 @@
                                             {% elif segment.status == segment.STATUS_ENABLED %}
                                                 <li><a href="{% url 'segment:toggle' segment.pk %}" title="{% trans "Disable this segment" %}">disable</a></li>
                                             {% endif %}
-                                            <li><a href="edit/{{ segment.pk }}" title="{% trans "Configure this segment" %}">configure this</a></li>
+                                            <li><a href="{% url 'wagtail_personalisation_segment_modeladmin_edit' segment.pk %}" title="{% trans "Configure this segment" %}">configure this</a></li>
                                         </ul>
                                         {% endif %}
                                     </div>


### PR DESCRIPTION
This is hardcoded at the moment which doesn't work unless you redirect URLs to have a trailing slash.

Using the reverse URL lookup works in all cases.