### PR TITLE
Update wagtail and django dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,8 @@ language: python
 
 matrix:
   include:
-    # Django 1.9, Wagtail 1.9
     - python: 2.7
-      env: TOXENV=py27-django19-wagtail19
+      env: TOXENV=py27-django111-wagtail113
 
 install:
   - pip install tox codecov

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import re
 from setuptools import find_packages, setup
 
 install_requires = [
-    'wagtail>=1.9,<1.11',
+    'wagtail>=1.10,<1.14',
     'user-agents>=1.0.1',
     'wagtailfontawesome>=1.0.6',
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,12 @@
 [tox]
-envlist = py{27}-django{19}-wagtail{19},lint
+envlist = py{27}-django{111}-wagtail{113},lint
 
 [testenv]
 commands = coverage run --parallel -m pytest {posargs}
 extras = test
 deps =
-    django19: django>=1.9,<1.10
-    wagtail19: wagtail>=1.9,<1.10
-    wagtail110: wagtail>=1.10,<1.11
+    django111: django>=1.11,<1.12
+    wagtail19: wagtail>=1.13,<1.14
 
 [testenv:coverage-report]
 basepython = python2.7


### PR DESCRIPTION
Tests now fail with Django 1.9 and Wagtail 1.9

This PR updates the versions of django and wagtail to those currently used by Molo  