### PR TITLE
Fix sampling for Dynamic segments

### DIFF
--- a/src/wagtail_personalisation/adapters.py
+++ b/src/wagtail_personalisation/adapters.py
@@ -193,7 +193,7 @@ class SessionSegmentsAdapter(BaseSegmentsAdapter):
                             segment.static_users.add(self.request.user)
                     additional_segments.append(segment)
                 elif result:
-                    if self.request.user.is_authenticated():
+                    if segment.is_static and self.request.user.is_authenticated():
                         segment.excluded_users.add(self.request.user)
 
         self.set_segments(current_segments + additional_segments)

--- a/tests/unit/test_static_dynamic_segments.py
+++ b/tests/unit/test_static_dynamic_segments.py
@@ -332,6 +332,7 @@ def test_offered_dynamic_segment_if_random_is_below_percentage(site, client, moc
     session.save()
     client.get(site.root_page.url)
 
+    assert len(client.session['excluded_segments']) == 0
     assert instance.id == client.session['segments'][0]['id']
 
 
@@ -341,7 +342,7 @@ def test_not_offered_dynamic_segment_if_random_is_above_percentage(site, client,
                                    randomisation_percent=40)
     rule = VisitCountRule(counted_page=site.root_page)
     form = form_with_data(segment, rule)
-    form.save()
+    instance = form.save()
 
     mocker.patch('random.randint', return_value=41)
     session = client.session
@@ -349,6 +350,7 @@ def test_not_offered_dynamic_segment_if_random_is_above_percentage(site, client,
     client.get(site.root_page.url)
 
     assert len(client.session['segments']) == 0
+    assert instance.id == client.session['excluded_segments'][0]['id']
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Store excluded segments in the session and don't store excluded users for dynamic segments