### PR TITLE
Remove static flag for Query Rule

### DIFF
--- a/src/wagtail_personalisation/rules.py
+++ b/src/wagtail_personalisation/rules.py
@@ -266,7 +266,6 @@ class QueryRule(AbstractBaseRule):
 
     """
     icon = 'fa-link'
-    static = True
 
     parameter = models.SlugField(_("The query parameter to search for"),
                                  max_length=20)
@@ -281,13 +280,7 @@ class QueryRule(AbstractBaseRule):
     class Meta:
         verbose_name = _('Query Rule')
 
-    def test_user(self, request, user=None):
-        if user:
-            # This rule currently does not support testing a user directly
-            # TODO: Make this test a user directly if/when the rule uses
-            # historical data
-            return False
-
+    def test_user(self, request):
         return request.GET.get(self.parameter, '') == self.value
 
     def description(self):

--- a/tests/unit/test_factories.py
+++ b/tests/unit/test_factories.py
@@ -45,4 +45,3 @@ def test_query_rule_create():
 
     assert query_rule.parameter == 'query'
     assert query_rule.value == 'value'
-    assert query_rule.static


### PR DESCRIPTION
In #6 I erroneously set the `static` flag on the Query rule. This rule should not be static.
In #7 I changed the `test_user` method of the Query rule to accept an optional `user` parameter. This is the expected behaviour for static rules.
This PR reverts those changes.