### PR TITLE
Get user info from visit count rule

### DIFF
--- a/src/wagtail_personalisation/rules.py
+++ b/src/wagtail_personalisation/rules.py
@@ -282,6 +282,28 @@ class VisitCountRule(AbstractBaseRule):
             ),
         }
 
+    def get_column_header(self):
+        return "Visit count - %s" % self.counted_page
+
+    def get_user_info_string(self, user):
+        # Local import for cyclic import
+        from wagtail_personalisation.adapters import (
+            get_segment_adapter, SessionSegmentsAdapter, SEGMENT_ADAPTER_CLASS)
+
+        # Create a fake request so we can use the adapter
+        request = RequestFactory().get('/')
+        request.user = user
+
+        # If we're using the session adapter check for an active session
+        if SEGMENT_ADAPTER_CLASS == SessionSegmentsAdapter:
+            request.session = self._get_user_session(user)
+        else:
+            request.session = SessionStore()
+
+        adapter = get_segment_adapter(request)
+        visit_count = adapter.get_visit_count(self.counted_page)
+        return str(visit_count)
+
 
 class QueryRule(AbstractBaseRule):
     """Query rule to segment users based on matching queries.

--- a/tests/unit/test_rules_visitcount.py
+++ b/tests/unit/test_rules_visitcount.py
@@ -1,5 +1,8 @@
 import pytest
 
+from tests.factories.rule import VisitCountRuleFactory
+from tests.factories.segment import SegmentFactory
+
 
 @pytest.mark.django_db
 def test_visit_count(site, client):
@@ -20,3 +23,29 @@ def test_visit_count(site, client):
     visit_count = client.session['visit_count']
     assert visit_count[0]['count'] == 2
     assert visit_count[1]['count'] == 1
+
+
+@pytest.mark.django_db
+def test_visit_count_call_test_user_with_user(site, client, user):
+    segment = SegmentFactory(name='VisitCount')
+    rule = VisitCountRuleFactory(counted_page=site.root_page, segment=segment)
+
+    session = client.session
+    session['visit_count'] = [{'path': '/', 'count': 2}]
+    session.save()
+    client.force_login(user)
+
+    assert rule.test_user(None, user)
+
+
+@pytest.mark.django_db
+def test_visit_count_call_test_user_with_user_or_request_fails(site, client, user):
+    segment = SegmentFactory(name='VisitCount')
+    rule = VisitCountRuleFactory(counted_page=site.root_page, segment=segment)
+
+    session = client.session
+    session['visit_count'] = [{'path': '/', 'count': 2}]
+    session.save()
+    client.force_login(user)
+
+    assert not rule.test_user(None)

--- a/tests/unit/test_rules_visitcount.py
+++ b/tests/unit/test_rules_visitcount.py
@@ -49,3 +49,24 @@ def test_visit_count_call_test_user_with_user_or_request_fails(site, client, use
     client.force_login(user)
 
     assert not rule.test_user(None)
+
+
+@pytest.mark.django_db
+def test_get_column_header(site):
+    segment = SegmentFactory(name='VisitCount')
+    rule = VisitCountRuleFactory(counted_page=site.root_page, segment=segment)
+
+    assert rule.get_column_header() == 'Visit count - Test page'
+
+
+@pytest.mark.django_db
+def test_get_user_info_string_returns_count(site, client, user):
+    segment = SegmentFactory(name='VisitCount')
+    rule = VisitCountRuleFactory(counted_page=site.root_page, segment=segment)
+
+    session = client.session
+    session['visit_count'] = [{'path': '/', 'count': 2}]
+    session.save()
+    client.force_login(user)
+
+    assert rule.get_user_info_string(user) == '2'


### PR DESCRIPTION
In order to show how a user matched the rules of a segment we need to get the user's data for each rule. Only the rule knows which field must be retrieved and what it should be called.
These methods will be called when compiling a csv of the users that matched a static segments rules.

This adds methods for getting that data to the Visit Count Rule.
This also allows the visit count rule to be tested against a user rather than a request.