### PR TITLE
Define panel for rules to handle InlinePanel changes

### DIFF
--- a/src/wagtail_personalisation/models.py
+++ b/src/wagtail_personalisation/models.py
@@ -21,6 +21,14 @@ from wagtail_personalisation.utils import count_active_days
 from .forms import SegmentAdminForm
 
 
+class RulePanel(InlinePanel):
+    def on_model_bound(self):
+        self.db_field = self.model._meta.get_field(
+            self.relation_name.replace('_related', 's'))
+        manager = getattr(self.model, self.relation_name)
+        self.related = manager.rel
+
+
 class SegmentQuerySet(models.QuerySet):
     def enabled(self):
         return self.filter(status=self.model.STATUS_ENABLED)
@@ -121,7 +129,7 @@ class Segment(ClusterableModel):
                 FieldPanel('randomisation_percent', classname='percent_field'),
             ], heading="Segment"),
             MultiFieldPanel([
-                InlinePanel(
+                RulePanel(
                     "{}_related".format(rule_model._meta.db_table),
                     label='{}{}'.format(
                         rule_model._meta.verbose_name,

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -6,6 +6,7 @@ import pytest
 
 from tests.factories.segment import SegmentFactory
 from wagtail_personalisation.rules import TimeRule
+from wagtail_personalisation.models import Segment
 
 
 @pytest.mark.django_db
@@ -25,3 +26,10 @@ def test_metadata_page_has_variants(segmented_page):
     canonical = segmented_page.personalisation_metadata.canonical_page
     assert canonical.personalisation_metadata.is_canonical
     assert canonical.personalisation_metadata.has_variants
+
+
+@pytest.mark.django_db
+def test_segment_edit_view(site, client, django_user_model):
+    test_segment = Segment()
+    new_panel = test_segment.panels[1].children[0].bind_to_model(Segment)
+    assert new_panel.related.name == "wagtail_personalisation_timerules"


### PR DESCRIPTION
The changes to EditHandlers brought in by Wagtail 2 meant that the InlinePanels used for rules weren't being linked to the rules and therefore weren't being displayed on the admin pages.

This is a workaround to deal with that