### PR TITLE
exclude variants should return a list when a list if given or a queryset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 .vscode/
 
 build/
+ve/
 dist/
 htmlcov/
 docs/_build

--- a/src/wagtail_personalisation/adapters.py
+++ b/src/wagtail_personalisation/adapters.py
@@ -186,8 +186,7 @@ class SessionSegmentsAdapter(BaseSegmentsAdapter):
         for segment in enabled_segments:
             if segment.is_static and segment.static_users.filter(id=self.request.user.id).exists():
                 additional_segments.append(segment)
-            elif (segment.excluded_users.filter(id=self.request.user.id).exists() or
-                    segment in excluded_segments):
+            elif (segment.excluded_users.filter(id=self.request.user.id).exists() or segment in excluded_segments):
                 continue
             elif not segment.is_static or not segment.is_full:
                 segment_rules = []

--- a/src/wagtail_personalisation/utils.py
+++ b/src/wagtail_personalisation/utils.py
@@ -103,17 +103,13 @@ def exclude_variants(pages):
     :return: List of pages that aren't variants
     :rtype: list
     """
-    return [
-        page for page in pages
-        if (
-            (
-                hasattr(page, 'personalisation_metadata') is False
-            ) or
-            (
-                hasattr(page, 'personalisation_metadata') and page.personalisation_metadata is None
-            ) or
-            (
-                hasattr(page, 'personalisation_metadata') and page.personalisation_metadata.is_canonical
-            )
-        )
-    ]
+
+    for page in pages:
+        if not ((hasattr(page, 'personalisation_metadata') is False
+                 ) or (hasattr(page, 'personalisation_metadata') and page.personalisation_metadata is None
+                       ) or (hasattr(page, 'personalisation_metadata') and page.personalisation_metadata.is_canonical)):
+                    if (type(pages) == list):
+                        pages.remove(page)
+                    else:
+                        pages.exclude(pk=page.pk)
+    return pages

--- a/src/wagtail_personalisation/utils.py
+++ b/src/wagtail_personalisation/utils.py
@@ -98,18 +98,18 @@ def parse_tag(token, parser):
 def exclude_variants(pages):
     """Checks if page is not a variant
 
-    :param pages: List of pages to check
-    :type pages: list
-    :return: List of pages that aren't variants
-    :rtype: list
+    :param pages: List | Queryset of pages to check
+    :type pages: list or querset
+    :return: List|Queryset of pages that aren't variants
+    :rtype: list or queryset (depending on the param type)
     """
 
     for page in pages:
-        if not ((hasattr(page, 'personalisation_metadata') is False
-                 ) or (hasattr(page, 'personalisation_metadata') and page.personalisation_metadata is None
-                       ) or (hasattr(page, 'personalisation_metadata') and page.personalisation_metadata.is_canonical)):
-                    if (type(pages) == list):
-                        pages.remove(page)
-                    else:
-                        pages.exclude(pk=page.pk)
+        if hasattr(page, 'personalisation_metadata') is not False and \
+           page.personalisation_metadata is not None and \
+           page.personalisation_metadata.is_canonical is not True:
+                if (type(pages) == list):
+                    pages.remove(page)
+                else:
+                    pages.exclude(pk=page.pk)
     return pages

--- a/src/wagtail_personalisation/utils.py
+++ b/src/wagtail_personalisation/utils.py
@@ -103,7 +103,6 @@ def exclude_variants(pages):
     :return: List|Queryset of pages that aren't variants
     :rtype: list or queryset (depending on the param type)
     """
-
     for page in pages:
         if hasattr(page, 'personalisation_metadata') is not False and \
            page.personalisation_metadata is not None and \
@@ -111,5 +110,5 @@ def exclude_variants(pages):
                 if (type(pages) == list):
                     pages.remove(page)
                 else:
-                    pages.exclude(pk=page.pk)
+                    pages = pages.exclude(pk=page.pk)
     return pages

--- a/src/wagtail_personalisation/wagtail_hooks.py
+++ b/src/wagtail_personalisation/wagtail_hooks.py
@@ -185,8 +185,7 @@ class PersonalisedPagesSummaryPanel(PagesSummaryItem):
     order = 2100
 
     def render(self):
-        page_count = models.PersonalisablePageMetadata.objects.filter(
-            segment__isnull=True).count()
+        page_count = models.PersonalisablePageMetadata.objects.filter(segment__isnull=True).count()
         title = _("Personalised Page")
         return mark_safe("""
             <li class="icon icon-fa-file-o">

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,10 @@ pytest_plugins = [
     'tests.fixtures'
 ]
 
+@pytest.fixture(autouse=True)
+def enable_db_access(db):
+    pass
+
 
 @pytest.fixture(scope='session')
 def django_db_setup(django_db_setup, django_db_blocker):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ pytest_plugins = [
     'tests.fixtures'
 ]
 
+
 @pytest.fixture(autouse=True)
 def enable_db_access(db):
     pass

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -63,7 +63,7 @@ def test_exclude_variants_excludes_pages_with_metadata_not_canonical():
 
 def test_exclude_variants_with_pages_querysets():
     '''
-    Test that excludes variant works for querysets too
+    Test that excludes variant works for querysets
     '''
     for i in range(5):
         page = WagtailPage(path="/" + str(i), depth=0, url_path="/", title="Hoi " + str(i))
@@ -77,7 +77,8 @@ def test_exclude_variants_with_pages_querysets():
 
 def test_exclude_variants_with_pages_querysets_not_canonical():
     '''
-    Test that excludes variant works for querysets too
+    Test that excludes variant works for querysets with
+    personalisation_metadata canonical False
     '''
     for i in range(5):
         page = WagtailPage(path="/" + str(i), depth=0, url_path="/", title="Hoi " + str(i))
@@ -95,7 +96,7 @@ def test_exclude_variants_with_pages_querysets_not_canonical():
 
 def test_exclude_variants_with_pages_querysets_meta_none():
     '''
-    Test that excludes variant works for querysets too
+    Test that excludes variant works for querysets with meta as none
     '''
     for i in range(5):
         page = WagtailPage(path="/" + str(i), depth=0, url_path="/", title="Hoi " + str(i))

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -65,8 +65,9 @@ def test_exclude_variants_with_pages_querysets():
     '''
     Test that excludes variant works for querysets too
     '''
-    page1 = WagtailPage(path="/", depth=0, url_path="/", title="Hoi")
-    page2 = WagtailPage(path="/", depth=0, url_path="/", title="Hoi")
+    for i in range(5):
+        page = WagtailPage(path="/" + str(i), depth=0, url_path="/", title="Hoi " + str(i))
+        page.save()
     pages = WagtailPage.objects.all().order_by('id')
     result = exclude_variants(pages)
     assert result == pages

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -69,5 +69,10 @@ def test_exclude_variants_with_pages_querysets():
         page = WagtailPage(path="/" + str(i), depth=0, url_path="/", title="Hoi " + str(i))
         page.save()
     pages = WagtailPage.objects.all().order_by('id')
+    # add variants
+    for page in pages:
+        page.personalisation_metadata = Metadata(is_canonical=False)
+    pages = WagtailPage.objects.all().order_by('id')
     result = exclude_variants(pages)
-    assert result == pages
+    assert type(result) == type(pages)
+    assert result != pages

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,6 +1,8 @@
 from wagtail_personalisation.utils import (
     exclude_variants, impersonate_other_page)
 
+from wagtail.core.models import Page as WagtailPage
+
 
 class Page(object):
     def __init__(self, path, depth, url_path, title):
@@ -57,3 +59,15 @@ def test_exclude_variants_excludes_pages_with_metadata_not_canonical():
     page.personalisation_metadata.is_canonical = False
     result = exclude_variants([page])
     assert result == []
+
+
+def test_exclude_variants_with_pages_querysets():
+    '''
+    Test that excludes variant works for querysets too
+    '''
+    page1 = WagtailPage(path="/", depth=0, url_path="/", title="Hoi")
+    page2 = WagtailPage(path="/", depth=0, url_path="/", title="Hoi")
+    pages = WagtailPage.objects.all().order_by('id')
+    print(pages)
+    result = exclude_variants(pages)
+    assert result == pages

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -69,10 +69,43 @@ def test_exclude_variants_with_pages_querysets():
         page = WagtailPage(path="/" + str(i), depth=0, url_path="/", title="Hoi " + str(i))
         page.save()
     pages = WagtailPage.objects.all().order_by('id')
+
+    result = exclude_variants(pages)
+    assert type(result) == type(pages)
+    assert result == pages
+
+
+def test_exclude_variants_with_pages_querysets_not_canonical():
+    '''
+    Test that excludes variant works for querysets too
+    '''
+    for i in range(5):
+        page = WagtailPage(path="/" + str(i), depth=0, url_path="/", title="Hoi " + str(i))
+        page.save()
+    pages = WagtailPage.objects.all().order_by('id')
     # add variants
     for page in pages:
         page.personalisation_metadata = Metadata(is_canonical=False)
-    pages = WagtailPage.objects.all().order_by('id')
+        page.save()
+
     result = exclude_variants(pages)
     assert type(result) == type(pages)
-    assert result != pages
+    assert result.count() == 0
+
+
+def test_exclude_variants_with_pages_querysets_meta_none():
+    '''
+    Test that excludes variant works for querysets too
+    '''
+    for i in range(5):
+        page = WagtailPage(path="/" + str(i), depth=0, url_path="/", title="Hoi " + str(i))
+        page.save()
+    pages = WagtailPage.objects.all().order_by('id')
+    # add variants
+    for page in pages:
+        page.personalisation_metadata = None
+        page.save()
+
+    result = exclude_variants(pages)
+    assert type(result) == type(pages)
+    assert result == pages

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -68,6 +68,5 @@ def test_exclude_variants_with_pages_querysets():
     page1 = WagtailPage(path="/", depth=0, url_path="/", title="Hoi")
     page2 = WagtailPage(path="/", depth=0, url_path="/", title="Hoi")
     pages = WagtailPage.objects.all().order_by('id')
-    print(pages)
     result = exclude_variants(pages)
     assert result == pages


### PR DESCRIPTION
This PR does a little bit more than it should.
1. Allow exclude variant to return a queryset when the `pages` param is not a list. Instead of creating a new list/queryset and returning it. The method now just removes the unwanted pages from the queryset/list and then returns the updates queryset/list
2. Added a method to testconf to allow db access for the test. The queryset tests require a models
3. Fix some flake8 errors that are occuring due to the update on flake8
4. add the ve to the `.gitignore` file